### PR TITLE
Instruct Cmake to look for libmaria in the right location for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ Install the c++ build chain for your operating system as well as [CMake](https:/
 	- Run `C:/path/to/msbuild.exe BSQL.sln`
 
 ### Linux
-
-- Install the i386 libmariadbclient-dev package for your system. The includes are expected to be in `/usr/include/mysql` and the libraries in `/usr/lib/i386-linux-gnu` (See the travis build chain for an example)
+- Dependencies (Debian based distros)
+- libmariadb2:i386 libmariadbclient-dev:i386 libssl1.1:i386 (exact libssl version probably doesn't matter exactly)
+- Cmake expects the includes to be in `/usr/include/mysql` and the libraries to be in `/usr/lib/i386-linux-gnu`, you'll have to adjust the paths in CMakelists if your distro does it differently
 - Generate makefiles with `cmake`
 - Use `make` to build
+#### Troubleshooting
+- Run ldd on the output .so file, ensure all dependencies exist and are valid
+- Run file on the output .so file and validate it's a 32 bit lib
 
 ## Integrating
 

--- a/src/BSQL/CMakeLists.txt
+++ b/src/BSQL/CMakeLists.txt
@@ -24,7 +24,7 @@ set(WSLIB ws2_32)
 else() #system package, this pmuch only works for travis
 set_target_properties(BSQL PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
 find_path(MARIA_INCLUDE_DIR NAMES "mysql.h" PATHS "/usr/include/mysql")
-find_library(MARIA_LIBRARY mariadb PATHS ~/MariaDB)
+find_library(MARIA_LIBRARY mariadb PATHS ~/MariaDB /usr/lib/i386-linux-gnu/)
 endif()
 
 include_directories(${MARIA_INCLUDE_DIR})


### PR DESCRIPTION
Quick pass on the readme to improve instructions for linux, and adding the path to libmaria as I could not get cmake to find the lib otherwise.