### PR TITLE
Fix bsql crashing when the connection gets re-made while a query is blocking

### DIFF
--- a/src/BSQL/MySqlConnectOperation.h
+++ b/src/BSQL/MySqlConnectOperation.h
@@ -23,7 +23,7 @@ public:
 	MySqlConnectOperation(MySqlConnection& connPool, const std::string& address, const unsigned short port, const std::string& username, const std::string& password, const std::string& database, const unsigned int timeout, std::atomic_uint_fast32_t& threadCounter, const unsigned int threadLimit);
 	MySqlConnectOperation(const MySqlConnectOperation&) = delete;
 	MySqlConnectOperation(MySqlConnectOperation&&) = delete;
-	~MySqlConnectOperation() override = default;
+	~MySqlConnectOperation() override;
 
 	bool IsComplete(bool noSkip) override;
 	bool IsQuery() override;

--- a/src/BSQL/MySqlConnection.cpp
+++ b/src/BSQL/MySqlConnection.cpp
@@ -93,7 +93,8 @@ void MySqlConnection::ReleaseConnection(MYSQL* connection) {
 	if (!newestConnectionAttemptKey.empty()) {
 		std::string tmp;
 		std::swap(tmp, newestConnectionAttemptKey);
-		if (!GetOperation(tmp)->IsComplete(false))
+		auto newestOperation(GetOperation(tmp));
+		if (newestOperation && !newestOperation->IsComplete(false))
 			std::swap(tmp, newestConnectionAttemptKey);
 	}
 }

--- a/src/BSQL/MySqlConnection.h
+++ b/src/BSQL/MySqlConnection.h
@@ -10,7 +10,6 @@ private:
 	std::string database;
 
 	std::stack<MYSQL*> availableConnections;
-	MYSQL* firstSuccessfulConnection;
 	std::string newestConnectionAttemptKey;
 
 	std::atomic_uint_fast32_t threadCounter;
@@ -27,6 +26,6 @@ public:
 	std::string CreateQuery(const std::string& queryText) override;
 	std::string Quote(const std::string& str) override;
 
-	MYSQL* RequestConnection(std::string& fail, int& failno, bool& doNotClose);
+	MYSQL* RequestConnection(std::string& fail, int& failno);
 	void ReleaseConnection(MYSQL* connection);
 };

--- a/src/BSQL/MySqlConnection.h
+++ b/src/BSQL/MySqlConnection.h
@@ -10,6 +10,7 @@ private:
 	std::string database;
 
 	std::stack<MYSQL*> availableConnections;
+	MYSQL* quoteConnection;
 	std::string newestConnectionAttemptKey;
 
 	std::atomic_uint_fast32_t threadCounter;

--- a/src/BSQL/MySqlQueryOperation.cpp
+++ b/src/BSQL/MySqlQueryOperation.cpp
@@ -61,7 +61,7 @@ void MySqlQueryOperation::QuestionableExit(MYSQL* mysql, std::shared_ptr<ClassSt
 		return;
 	}
 	localClassState->lock.unlock();
-	--*threadCounter;
+	--threadCounter;
 }
 
 void MySqlQueryOperation::StartQuery(MYSQL* mysql, std::string&& localQueryText, std::shared_ptr<ClassState> localClassState) {

--- a/src/BSQL/MySqlQueryOperation.h
+++ b/src/BSQL/MySqlQueryOperation.h
@@ -5,7 +5,6 @@ private:
 	std::string queryText;
 	MySqlConnection& connPool;
 	MYSQL* connection;
-	bool noClose;
 	std::shared_ptr<ClassState> state;
 	std::queue<std::string> results;
 	int connectionAttempts;

--- a/src/BSQL/Operation.h
+++ b/src/BSQL/Operation.h
@@ -6,6 +6,7 @@ protected:
 	struct ClassState {
 		std::mutex lock;
 		bool alive = true;
+		bool zombie = false;
 	};
 protected:
 	int errnum;


### PR DESCRIPTION
Long story short: Use after free on `this`. Added a `zombie` bool to the state struct to detect this, added logic to check/set it.

@Cyberboss @SpaceManiac @optimumtact 

~~I haven't tested this without the shared_ptr change me and spacemaniac were trying out yet, but the test that still had that change worked fine.~~

Edit: found and fixed a second crash with firstSuccessfulConnection shared use:
`firstSuccessfulConnection` kept a reference even when it was given to a `QuertyOperation` thread, if the `MySqlConnection` was later deleted, it could close this handle while mysql was still using it in the `QueryOperation` thread.

~~The solution was to kill `firstSuccessfulConnection`. It only existed for `mysql_real_escape_string`, and making that hold on to and release a connection is a better solution that lowers the complexity of the overall system.~~ I made sql_sanitize block by doing this, I can think of a better way.