### PR TITLE
Release Query on completion

### DIFF
--- a/src/BSQL/MySqlQueryOperation.cpp
+++ b/src/BSQL/MySqlQueryOperation.cpp
@@ -49,7 +49,7 @@ void MySqlQueryOperation::QuestionableExit(MYSQL* mysql, std::shared_ptr<ClassSt
 			errnum = tmpErr;
 		}
 	}
-	else if (!noClose)
+	if (!noClose)
 		mysql_close(mysql);
 	mysql_thread_end();
 	localClassState->lock.unlock();


### PR DESCRIPTION
IMO (and it is sorta confirmed by local testing) the major issue with BSQL is that it never releases query handle due to that condition never being hit. The query execution itself is not affected (tested on 770+ queries and commands, everything worked as before)

Basically you should be fine running 150 total connections (as per MYSQL default) and never getting BSQL hanged or requiring dropping connection and reconnecting.

Whatever other solution is found it HAS to release handles or as soon as you hit the limit you are bonked